### PR TITLE
Add 'around' to syntax

### DIFF
--- a/Syntaxes/RSpec.tmLanguage
+++ b/Syntaxes/RSpec.tmLanguage
@@ -50,7 +50,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(before|after)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(before|after|around)\b(?![?!])</string>
 			<key>name</key>
 			<string>keyword.other.rspec</string>
 		</dict>


### PR DESCRIPTION
Hey,

I noticed around is not on the syntax.
If you like this I can add a snippet for it as well.
