### PR TITLE
Make sure meta.rspec.pending is not used for lines ending in 'do'.

### DIFF
--- a/Syntaxes/RSpec.tmLanguage
+++ b/Syntaxes/RSpec.tmLanguage
@@ -157,7 +157,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(it|specify)\s+(.*[^do])\s*$</string>
+			<string>^\s*(it|specify)\s+(.*\S)(?&lt;!do)\s*$</string>
 			<key>name</key>
 			<string>meta.rspec.pending</string>
 		</dict>


### PR DESCRIPTION
Fixes incorrect highlighting of the 'do' keyword (and additional options, if present) as 'string.ruby'.
