### PR TITLE
Remove rvm specific support

### DIFF
--- a/Commands/Run Focussed Specification.tmCommand
+++ b/Commands/Run Focussed Specification.tmCommand
@@ -7,8 +7,6 @@
 	<key>command</key>
 	<string>#!/usr/bin/env bash
 
-. "$TM_BUNDLE_SUPPORT/lib/rvm_textmate"
-
 cat &lt;&lt;'RUBYEOF' &gt; /tmp/textmate-command-$$.rb
 
 require ENV['TM_BUNDLE_SUPPORT'] + "/lib/rspec/mate"

--- a/Commands/Run Last Examples file.tmCommand
+++ b/Commands/Run Last Examples file.tmCommand
@@ -7,8 +7,6 @@
 	<key>command</key>
 	<string>#!/usr/bin/env bash
 
-. "$TM_BUNDLE_SUPPORT/lib/rvm_textmate"
-
 cat &lt;&lt;'RUBYEOF' &gt; /tmp/textmate-command-$$.rb
 
 require ENV['TM_BUNDLE_SUPPORT'] + "/lib/rspec/mate"

--- a/Commands/Run Specifications - Normal.tmCommand
+++ b/Commands/Run Specifications - Normal.tmCommand
@@ -7,8 +7,6 @@
 	<key>command</key>
 	<string>#!/usr/bin/env bash
 
-. "$TM_BUNDLE_SUPPORT/lib/rvm_textmate"
-
 cat &lt;&lt;'RUBYEOF' &gt; /tmp/textmate-command-$$.rb
 
 require ENV['TM_BUNDLE_SUPPORT'] + "/lib/rspec/mate"

--- a/Commands/Run Specifications in selected files or directories.tmCommand
+++ b/Commands/Run Specifications in selected files or directories.tmCommand
@@ -7,8 +7,6 @@
 	<key>command</key>
 	<string>#!/usr/bin/env bash
 
-. "$TM_BUNDLE_SUPPORT/lib/rvm_textmate"
-
 cat &lt;&lt;'RUBYEOF' &gt; /tmp/textmate-command-$$.rb
 
 require ENV['TM_BUNDLE_SUPPORT'] + "/lib/rspec/mate"

--- a/Support/lib/rvm_textmate
+++ b/Support/lib/rvm_textmate
@@ -1,2 +1,0 @@
-[[ -f "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-[[ -f "$TM_PROJECT_DIRECTORY/.rvmrc" ]] && . "$TM_PROJECT_DIRECTORY/.rvmrc"


### PR DESCRIPTION
My idea here is to delegate ruby detection to the user.
Use TM_RUBY or fallback to system ruby.
I've been using rbenv like this https://gist.github.com/1330916 with success.
The same thing can be done for rvm https://rvm.io/integration/textmate/ .
If you like this I can update the README accordingly.

This is related to https://github.com/rspec/rspec-tmbundle/pull/33
