### PR TITLE
Snippets for expect, expect with block and change.

### DIFF
--- a/Snippets/change.tmSnippet
+++ b/Snippets/change.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>content</key>
+  <string>change { $1 }</string>
+  <key>name</key>
+  <string>change</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>ch</string>
+  <key>uuid</key>
+  <string>BAA8F11E-499B-4786-947F-603C1687E078</string>
+</dict>
+</plist>

--- a/Snippets/expect.tmSnippet
+++ b/Snippets/expect.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>content</key>
+  <string>expect(${1:target}).to</string>
+  <key>name</key>
+  <string>expect</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>exp</string>
+  <key>uuid</key>
+  <string>45959A25-330C-4CC0-93EC-075817C95ACC</string>
+</dict>
+</plist>

--- a/Snippets/expect_block.tmSnippet
+++ b/Snippets/expect_block.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>content</key>
+  <string>expect { ${1:target} }.to</string>
+  <key>name</key>
+  <string>expect with block</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>expb</string>
+  <key>uuid</key>
+  <string>A242D343-202A-44D2-B106-3E7EAF1926D2</string>
+</dict>
+</plist>


### PR DESCRIPTION
Added snippets for expect, expect with block and change, to use with RSpec's new expectation syntax. I've left `info.plist` untouched as I wasn't sure where to add entries for these snippets.
