### PR TITLE
RVM and .ruby-version

### DIFF
--- a/Support/lib/rvm_textmate
+++ b/Support/lib/rvm_textmate
@@ -1,2 +1,3 @@
 [[ -f "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
 [[ -f "$TM_PROJECT_DIRECTORY/.rvmrc" ]] && . "$TM_PROJECT_DIRECTORY/.rvmrc"
+[[ -f "$TM_PROJECT_DIRECTORY/.ruby-version" ]] && cd "$TM_PROJECT_DIRECTORY"


### PR DESCRIPTION
RVM is starting using .ruby-version instead of .rvmrc. The .ruby-version is just a single-line file containing ruby identifier string. In order to make rvm-auto-ruby pick right ruby we can cd to project directory. Not sure if it's the best solution, but it works fine to me.
