### PR TITLE
setup bundler from TM_PROJECT_DIRECTORY so it finds a gemfile when BUNDLE_GEMFILE isn't set

### DIFF
--- a/Support/lib/rspec/mate.rb
+++ b/Support/lib/rspec/mate.rb
@@ -56,7 +56,9 @@ if use_bundler?
   require "rubygems"
   require "bundler"
 
-  Bundler.setup
+  Dir.chdir File.expand_path(ENV['TM_PROJECT_DIRECTORY']) do
+    Bundler.setup
+  end
 else
   rspec_lib = find_rspec_lib
 


### PR DESCRIPTION
Because Textmate commands are run from dynamically generated files in /tmp Bundler.setup does not find the proper Gemfile because its searching in /tmp instead of the project folder. This change just runs Bundler.setup from the current project directory, so if BUNDLE_GEMFILE isn't set it falls back to the correct default.

There is a stack trace that set me down the path to this commit, but instead of pasting it here I think it suffices to say that bundler threw Bundler::GemfileNotFound and it traced back to this call to Bundler.setup.
