### PR TITLE
Adding feature and scenario to the syntax

### DIFF
--- a/Syntaxes/RSpec.tmLanguage
+++ b/Syntaxes/RSpec.tmLanguage
@@ -80,7 +80,7 @@
 		<key>behaviour</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(describe|context)\b</string>
+			<string>^\s*(describe|context|feature)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -112,7 +112,7 @@
 		<key>example</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(it|specify)\b</string>
+			<string>^\s*(it|specify|scenario)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -157,7 +157,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(it|specify)\s+(.*\S)(?&lt;!do)\s*$</string>
+			<string>^\s*(it|specify|scenario)\s+(.*\S)(?&lt;!do)\s*$</string>
 			<key>name</key>
 			<string>meta.rspec.pending</string>
 		</dict>
@@ -172,7 +172,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(it|specify)\s*{</string>
+			<string>^\s*(it|specify|scenario)\s*{</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
This is an addition to issue #58. It adds `feature` and `scenario` to the syntax.

`feature` is like `describe` and `scenario` is like `it`.
