### PR TITLE
Change scope to source.ruby.rspec

### DIFF
--- a/Commands/Run Last Examples file.tmCommand
+++ b/Commands/Run Last Examples file.tmCommand
@@ -28,7 +28,7 @@ ${TM_RUBY:-ruby} /tmp/textmate-command-$$.rb; exit_status=$?; rm /tmp/textmate-c
 	<key>output</key>
 	<string>showAsHTML</string>
 	<key>scope</key>
-	<string>source.ruby</string>
+	<string>source.ruby.rspec</string>
 	<key>uuid</key>
 	<string>1C172C2C-8785-40FC-B03E-7FF56AC0B266</string>
 </dict>


### PR DESCRIPTION
Scope should be source.ruby.rspec (analogous to the other commands in this bundle). Otherwise it somewhat conflicts with running single Test::Unit tests in Ruby.tmbundle if two identical keyboard shortcuts are set.
