### PR TITLE
Update switch_command.rb

### DIFF
--- a/Support/lib/rspec/mate/switch_command.rb
+++ b/Support/lib/rspec/mate/switch_command.rb
@@ -176,13 +176,11 @@ SPEC
 
       def write_and_open(path, content)
         `mkdir -p "#{File.dirname(path)}"`
-        `touch "#{path}"`
+        File.open(path, 'w') do |f|
+          f.write "# -*- encoding : utf-8 -*-
+require 'spec_helper'"
+        end
         `"$TM_SUPPORT_PATH/bin/mate" "#{path}"`
-        `osascript &>/dev/null -e 'tell app "SystemUIServer" to activate' -e 'tell app "TextMate" to activate'`
-
-        escaped_content = content.gsub("\n","\\n").gsub('$','\\$').gsub('"','\\\\\\\\\\\\"')
-
-        `osascript &>/dev/null -e "tell app \\"TextMate\\" to insert \\"#{escaped_content}\\" as snippet true"`
       end
     end
   end


### PR DESCRIPTION
Fix open alt-file by inserting a simple template,
bypassing code broken in TM2 and recent OS X.

The existing code locks up TM 2.0-alpha.9501 on Mavericks. 

There's an existing ticket from half a year or more ago, #38, but no commits. I've just had to re-discover the solution via Google.

There's missing functionality vs the original, e.g. not inserting model or controller templates depending on the file switched from, but is that worth having? File switching without crashing TM2 seems more important?
