### PR TITLE
Fix clickable links in TextMate html output

### DIFF
--- a/Support/lib/rspec/mate/text_mate_formatter.rb
+++ b/Support/lib/rspec/mate/text_mate_formatter.rb
@@ -28,6 +28,44 @@ module RSpec
           @snippet_extractor ||= RSpec::Core::Formatters::SnippetExtractor.new
           "    <pre class=\"ruby\"><code>#{@snippet_extractor.snippet(backtrace)}</code></pre>"
         end
+        
+        def example_failed(example)
+          # super(example)
+
+          unless @header_red
+            @header_red = true
+            @printer.make_header_red
+          end
+
+          unless @example_group_red
+            @example_group_red = true
+            @printer.make_example_group_header_red(example_group_number)
+          end
+
+          @printer.move_progress(percent_done)
+
+          exception = example.metadata[:execution_result][:exception]
+          exception_details = if exception
+            {
+              :message => exception.message,
+              :backtrace => format_backtrace(exception.backtrace, example).join("\n")
+            }
+          else
+            false
+          end
+          extra = extra_failure_content(exception)
+
+          @printer.print_example_failed(
+            example.execution_result[:pending_fixed],
+            example.description,
+            example.execution_result[:run_time],
+            @failed_examples.size,
+            exception_details,
+            (extra == "") ? false : extra,
+            false
+          )
+          @printer.flush
+        end
       end
     end
   end


### PR DESCRIPTION
Right now for me running the latest RSpec, TextMate 2 alpha, Rails 4, and this bundle, when I run my specs and get html output in TextMate, the links are not clickable. I brought it up in rspec-core (https://github.com/rspec/rspec-core/issues/1276#issuecomment-33680781) and they pointed me here. This proposed change fixes the issue for me.

This code is the example_failed method inside the rspec-core HtmlFormatter, with the 'super' call removed, and the last argument on @printer.print_example_failed set to false (to not escape the html).
