### PR TITLE
Fix for rspec-core < v2.12.0

### DIFF
--- a/Support/lib/rspec/mate/text_mate_formatter.rb
+++ b/Support/lib/rspec/mate/text_mate_formatter.rb
@@ -30,8 +30,17 @@ module RSpec
         end
         
         def example_failed(example)
-          # super(example)
-
+          if @printer
+            # @printer was introduced in rspec-core v2.12.0 - https://github.com/rspec/rspec-core/commit/38306aef366a1d60b3d0d9f37788d0c2d1e58804
+            example_failed_with_printer(example)
+          else
+            super
+          end
+        end
+        
+        def example_failed_with_printer(example)
+          @failed_examples << example
+          
           unless @header_red
             @header_red = true
             @printer.make_header_red


### PR DESCRIPTION
As mentioned in #66, older rspec-core versions will give the error `NoMethodError: undefined method`make_example_group_header_red' for nil:NilClass`. This patch checks for the key change and avoids it if necessary.
