### PR TITLE
Revert back to textmate formatter

### DIFF
--- a/Support/lib/rspec/mate.rb
+++ b/Support/lib/rspec/mate.rb
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__) + '/..')
 require 'rspec/mate/runner'
 require 'rspec/mate/options'
 require 'rspec/mate/switch_command'
-require 'rspec/mate/text_mate_formatter'
+#require 'rspec/mate/text_mate_formatter'
 
 rspec_lib = nil
 
@@ -49,7 +49,7 @@ def gemfile?
 end
 
 def use_bundler?
-  bundler_option? || (gemfile? && skip_bundler_option?)
+  bundler_option? || (gemfile? && !skip_bundler_option?)
 end
 
 

--- a/Support/lib/rspec/mate/runner.rb
+++ b/Support/lib/rspec/mate/runner.rb
@@ -35,7 +35,7 @@ module RSpec
       end
 
       def run(stdout, options)
-        formatter  = ENV['TM_RSPEC_FORMATTER'] || 'RSpec::Mate::Formatters::TextMateFormatter'
+        formatter  = ENV['TM_RSPEC_FORMATTER'] || 'textmate'#'RSpec::Mate::Formatters::TextMateFormatter'
         stderr     = StringIO.new
         old_stderr = $stderr
         $stderr    = stderr


### PR DESCRIPTION
This commit reverts pull request #49, fixes issues #68, #52

RSpec::Mate::Formatters::TextMateFormatter doesn't work with Bundler because it tries to load 'rspec/core/formatters/html_formatter' early before Bundler.setup, while there is no rspec libraries on the load_path yet.

Also, there are some issues with RSpec::Mate::Formatters::TextMateFormatter's output, like formats, links, while 'textmate' formatter works fine with textmate.
