### PR TITLE
Use binstub if present

### DIFF
--- a/Support/lib/rspec/mate.rb
+++ b/Support/lib/rspec/mate.rb
@@ -45,13 +45,22 @@ def gemfile?
   File.exist?(File.join(ENV['TM_PROJECT_DIRECTORY'], 'Gemfile'))
 end
 
+def use_binstub?
+  # Using binstub means we need to look at the Gemfile to determine RSpec version,
+  # so having a Gemfile is mandatory.
+  gemfile? && File.exist?(File.join(ENV['TM_PROJECT_DIRECTORY'], 'bin', 'rspec'))
+end
+
 def use_bundler?
   bundler_option? || (gemfile? && !skip_bundler_option?)
 end
 
 def rspec_version
   @rspec_version ||= begin
-    if defined?(RSpec::Core)
+    if use_binstub?
+      specs = Bundler::LockfileParser.new(Bundler.read_file(File.join(ENV['TM_PROJECT_DIRECTORY'], 'Gemfile.lock'))).specs
+      specs.detect{ |s| s.name == "rspec-core" }.version.to_s
+    elsif defined?(RSpec::Core)
       RSpec::Core::Version::STRING
     elsif defined?(Spec::Version)
       Spec::VERSION::STRING
@@ -71,11 +80,11 @@ end
 
 rspec_lib = nil
 
-if use_bundler?
+if use_binstub? || use_bundler?
   require "rubygems"
   require "bundler"
 
-  Bundler.setup
+  Bundler.setup if use_bundler?
 else
   rspec_lib = find_rspec_lib
 
@@ -84,7 +93,9 @@ else
   end
 end
 
-if RSpec::Mate::Options['--rspec-version']
+if use_binstub?
+  # Nothing to do here
+elsif RSpec::Mate::Options['--rspec-version']
   if RSpec::Mate::Options['--rspec-version'] =~ /^2/
     require 'rspec/core'
   else

--- a/Support/lib/rspec/mate/runner.rb
+++ b/Support/lib/rspec/mate/runner.rb
@@ -56,7 +56,9 @@ module RSpec
         end
 
         Dir.chdir(project_directory) do
-          if rspec3? || rspec2?
+          if use_binstub?
+             system 'bin/rspec', *argv
+          elsif rspec3? || rspec2?
             ::RSpec::Core::Runner.disable_autorun!
             ::RSpec::Core::Runner.run(argv, stderr, stdout)
           else


### PR DESCRIPTION
Look for "bin/rspec" and use it, if present. This dramatically improves RSpec’s start up time for projects using an application preloader like Spring (as long as the preloader generates a suitable binstub).

Note that the binstub is only used if there is a Gemfile present (otherwise it would not be possible to determine the RSpec version).

Also includes two other small improvements / refactorings for exception handling and RSpec version detection.
